### PR TITLE
PRQL join parse implementation added along with unit tests.

### DIFF
--- a/tests/dialects/test_prql.py
+++ b/tests/dialects/test_prql.py
@@ -167,3 +167,118 @@ class TestPRQL(Validator):
                 "": "SELECT MIN(y), STDDEV(x) AS b, MAX(z) FROM a",
             },
         )
+        self.validate_all(
+            "from tracks join side:left artists (artists.id==tracks.artist_id && artists.country=='UK')",
+            write={
+                "": "SELECT * FROM tracks LEFT JOIN artists ON artists.id = tracks.artist_id AND artists.country = 'UK'"
+            },
+        )
+        self.validate_all(
+            "from employees join side:left p=positions (employees.id==p.employee_id)",
+            write={
+                "": "SELECT * FROM employees LEFT JOIN positions AS p ON employees.id = p.employee_id"
+            },
+        )
+        self.validate_all(
+            "from employees join side:full departments (employees.dept_id==departments.id)",
+            write={
+                "": "SELECT * FROM employees FULL JOIN departments ON employees.dept_id = departments.id",
+            },
+        )
+        self.validate_all(
+            "from employees join side:right positions (employees.id==positions.employee_id)",
+            write={
+                "": "SELECT * FROM employees RIGHT JOIN positions ON employees.id = positions.employee_id",
+            },
+        )
+        self.validate_all(
+            "from shirts join hats true", write={"": "SELECT * FROM shirts INNER JOIN hats ON TRUE"}
+        )
+        self.validate_all(
+            "from tracks join side:inner artists (this.id==that.artist_id)",
+            write={"": "SELECT * FROM tracks INNER JOIN artists ON tracks.id = artists.artist_id"},
+        )
+        self.validate_all(
+            "from employees join e=employees (employees.manager_id==e.id)",
+            write={
+                "": "SELECT * FROM employees INNER JOIN employees AS e ON employees.manager_id = e.id",
+            },
+        )
+        self.validate_all(
+            "from employees join positions (==emp_no)",
+            write={
+                "": "SELECT * FROM employees INNER JOIN positions ON employees.emp_no = positions.emp_no"
+            },
+        )
+        self.validate_all(
+            "from orders join customers (==customer_id) join products (orders.product_id==products.id)",
+            write={
+                "": "SELECT * FROM orders INNER JOIN customers ON orders.customer_id = customers.customer_id INNER JOIN products ON orders.product_id = products.id",
+            },
+        )
+        self.validate_all(
+            "from employees join side:left positions (employees.id==positions.employee_id && (positions.title=='Manager' || positions.level>5))",
+            write={
+                "": "SELECT * FROM employees LEFT JOIN positions ON employees.id = positions.employee_id AND (positions.title = 'Manager' OR positions.level > 5)",
+            },
+        )
+        self.validate_all(
+            "from sales join products (products.id == sales.product_id && products.category == 'electronics')",
+            write={
+                "": "SELECT * FROM sales INNER JOIN products ON products.id = sales.product_id AND products.category = 'electronics'",
+            },
+        )
+        self.validate_all(
+            "from employees join side:full positions (employees.id==positions.employee_id && positions.department_id!=employees.dept_id)",
+            write={
+                "": "SELECT * FROM employees FULL JOIN positions ON employees.id = positions.employee_id AND positions.department_id <> employees.dept_id",
+            },
+        )
+        self.validate_all(
+            "from employees join side:inner departments (==dept_id) join side:left m=managers (employees.manager_id==m.id) join side:inner projects (employees.project_id==projects.id && projects.status=='active')",
+            write={
+                "": "SELECT * FROM employees INNER JOIN departments ON employees.dept_id = departments.dept_id LEFT JOIN managers AS m ON employees.manager_id = m.id INNER JOIN projects ON employees.project_id = projects.id AND projects.status = 'active'",
+            },
+        )
+        self.validate_all(
+            "from orders join o=orders (this.customer_id==that.customer_id && that.id!=this.id)",
+            write={
+                "": "SELECT * FROM orders INNER JOIN orders AS o ON orders.customer_id = o.customer_id AND o.id <> orders.id",
+            },
+        )
+        self.validate_all(
+            "from shirts join hats true join s=shoes true",
+            write={
+                "": "SELECT * FROM shirts INNER JOIN hats ON TRUE INNER JOIN shoes AS s ON TRUE",
+            },
+        )
+        self.validate_all(
+            "from orders join side:left customers (orders.customer_id==customers.id) join side:inner products (orders.product_id==products.id)",
+            write={
+                "": "SELECT * FROM orders LEFT JOIN customers ON orders.customer_id = customers.id INNER JOIN products ON orders.product_id = products.id",
+            },
+        )
+        self.validate_all(
+            "from employees join departments (employees.dept_id==departments.id) filter (employees.tenure > 10)",
+            write={
+                "": "SELECT * FROM employees INNER JOIN departments ON employees.dept_id = departments.id WHERE (employees.tenure > 10)",
+            },
+        )
+        self.validate_all(
+            "from employees join departments (employees.dept_id==departments.id && (departments.location=='HQ' || departments.budget > 100000))",
+            write={
+                "": "SELECT * FROM employees INNER JOIN departments ON employees.dept_id = departments.id AND (departments.location = 'HQ' OR departments.budget > 100000)"
+            },
+        )
+        self.validate_all(
+            "from employees join manager=employees (employees.manager_id==manager.id) join director=employees (employees.director_id==director.id)",
+            write={
+                "": "SELECT * FROM employees INNER JOIN employees AS manager ON employees.manager_id = manager.id INNER JOIN employees AS director ON employees.director_id = director.id"
+            },
+        )
+        self.validate_all(
+            "from shirts join hats true join side:left shoes true join side:right bags (shirts.id==bags.id) join accessories true filter shirts.in_stock == true && hats.is_available == true",
+            write={
+                "": "SELECT * FROM shirts INNER JOIN hats ON TRUE LEFT JOIN shoes ON TRUE RIGHT JOIN bags ON shirts.id = bags.id INNER JOIN accessories ON TRUE WHERE shirts.in_stock = TRUE AND hats.is_available = TRUE"
+            },
+        )


### PR DESCRIPTION
This commit creates a join parser for PRQL in SQLGLOT, supporting different join types, table aliases, self-joins, and complex join conditions.

The key changes are outlined below:

1. **Support for Multiple JOIN Types:**
   - **INNER JOIN:** Default join type when no specific side is mentioned.
   - **LEFT JOIN:** Parses `SIDE:LEFT` to perform left outer joins.
   - **RIGHT JOIN:** Parses `SIDE:RIGHT` to perform right outer joins.
   - **FULL JOIN:** Parses `SIDE:FULL` for full outer joins.
   - **CROSS JOIN:** Identified by the keyword `TRUE` after the table name.

2. **Handling Table Aliases and Self-Joins:**
   - Allows specifying table aliases using the `=` syntax.
   - Supports self-joins by enabling the same table to be joined multiple times with different aliases.

3. **Parsing Complex Join Conditions:**
   - Replaces placeholders (`this` and `that`) with actual table names to maintain clarity in self-joins and aliases.

4. **New Methods Introduced:**
   - **`_parse_join`:** Main method to parse `JOIN` clauses, determine join type, handle aliases, and construct the join expression.
   - **`_match_side`:** Identifies and returns the specified join side (`LEFT`, `RIGHT`, `FULL`, `INNER`).
   - **`_parse_join_condition`:** Extracts and builds the join condition.
   - **`_replace_this_that`:** Replaces placeholder references (`this`, `that`) in join conditions with the table names.